### PR TITLE
Formatted code and removed "(c)" from copyright banners.

### DIFF
--- a/include/crc32c/crc32c.h
+++ b/include/crc32c/crc32c.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
@@ -13,7 +13,7 @@
 
 namespace crc32c {
 
-// Extends "crc" with the CRC32 of "count" bytes in the buffer pointed by
+// Extends "crc" with the CRC32C of "count" bytes in the buffer pointed by
 // "data".
 uint32_t Extend(uint32_t crc, const uint8_t* data, size_t count);
 

--- a/src/crc32c.cc
+++ b/src/crc32c.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
@@ -18,12 +18,10 @@ namespace crc32c {
 uint32_t Extend(uint32_t crc, const uint8_t* data, size_t count) {
 #if defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
   static bool can_use_sse42 = CanUseSse42();
-  if (can_use_sse42)
-    return ExtendSse42(crc, data, count);
+  if (can_use_sse42) return ExtendSse42(crc, data, count);
 #elif defined(HAVE_ARM64_CRC32C)
   static bool can_use_arm_linux = CanUseArm64Linux();
-  if (can_use_arm_linux)
-    return ExtendArm64(crc, data, count);
+  if (can_use_arm_linux) return ExtendArm64(crc, data, count);
 #endif
 
   return ExtendPortable(crc, data, count);

--- a/src/crc32c_arm64.h
+++ b/src/crc32c_arm64.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
@@ -20,6 +20,6 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t* data, size_t count);
 
 }  // namespace crc32c
 
-#endif // defined(HAVE_ARM64_CRC32C)
+#endif  // defined(HAVE_ARM64_CRC32C)
 
 #endif  // CRC32C_CRC32C_ARM_LINUX_H_

--- a/src/crc32c_arm64_linux_check.h
+++ b/src/crc32c_arm64_linux_check.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_arm64_unittest.cc
+++ b/src/crc32c_arm64_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_benchmark.cc
+++ b/src/crc32c_benchmark.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
@@ -71,7 +71,7 @@ BENCHMARK_REGISTER_F(CRC32CBenchmark, ArmLinux)
     ->Range(256, 16777216);  // Block size.
 #endif                       // defined(HAVE_ARM64_CRC32C)
 
-#if defined(HAVE_SSE42)  && (defined(_M_X64) || defined(__x86_64__))
+#if defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
 
 BENCHMARK_DEFINE_F(CRC32CBenchmark, Sse42)(benchmark::State& state) {
   if (!crc32c::CanUseSse42()) {

--- a/src/crc32c_config.h.in
+++ b/src/crc32c_config.h.in
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_extend_unittests.h
+++ b/src/crc32c_extend_unittests.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
@@ -77,11 +77,9 @@ TEST(TESTED_EXTEND_CASE_NAME, BufferSlicing) {
     for (size_t j = i + 1; j <= 48; ++j) {
       uint32_t crc = 0;
 
-      if (i > 0)
-        crc = TESTED_EXTEND(crc, buffer, i);
+      if (i > 0) crc = TESTED_EXTEND(crc, buffer, i);
       crc = TESTED_EXTEND(crc, buffer + i, j - i);
-      if (j < 48)
-        crc = TESTED_EXTEND(crc, buffer + j, 48 - j);
+      if (j < 48) crc = TESTED_EXTEND(crc, buffer + j, 48 - j);
 
       EXPECT_EQ(static_cast<uint32_t>(0xd9963a56), crc);
     }
@@ -97,11 +95,9 @@ TEST(TESTED_EXTEND_CASE_NAME, LargeBufferSlicing) {
     for (size_t j = i + 1; j <= 2048; ++j) {
       uint32_t crc = 0;
 
-      if (i > 0)
-        crc = TESTED_EXTEND(crc, buffer, i);
+      if (i > 0) crc = TESTED_EXTEND(crc, buffer, i);
       crc = TESTED_EXTEND(crc, buffer + i, j - i);
-      if (j < 2048)
-        crc = TESTED_EXTEND(crc, buffer + j, 2048 - j);
+      if (j < 2048) crc = TESTED_EXTEND(crc, buffer + j, 2048 - j);
 
       EXPECT_EQ(static_cast<uint32_t>(0x36dcc753), crc);
     }

--- a/src/crc32c_internal.h
+++ b/src/crc32c_internal.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_portable.cc
+++ b/src/crc32c_portable.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
@@ -250,38 +250,40 @@ uint32_t ExtendPortable(uint32_t crc, const uint8_t* data, size_t size) {
   uint32_t l = crc ^ kCRC32Xor;
 
 // Process one byte at a time.
-#define STEP1                               \
-  do {                                      \
-    int c = (l & 0xff) ^ *p++;              \
-    l = kByteExtensionTable[c] ^ (l >> 8);  \
+#define STEP1                              \
+  do {                                     \
+    int c = (l & 0xff) ^ *p++;             \
+    l = kByteExtensionTable[c] ^ (l >> 8); \
   } while (0)
 
 // Process one of the 4 strides of 4-byte data.
-#define STEP4(s) do {                        \
-  crc##s = ReadUint32LE(p + s * 4) ^         \
-           kStrideExtensionTable3[crc##s & 0xff] ^          \
-           kStrideExtensionTable2[(crc##s >> 8) & 0xff] ^   \
-           kStrideExtensionTable1[(crc##s >> 16) & 0xff] ^  \
-           kStrideExtensionTable0[crc##s >> 24];            \
-} while (0)
+#define STEP4(s)                                                               \
+  do {                                                                         \
+    crc##s = ReadUint32LE(p + s * 4) ^ kStrideExtensionTable3[crc##s & 0xff] ^ \
+             kStrideExtensionTable2[(crc##s >> 8) & 0xff] ^                    \
+             kStrideExtensionTable1[(crc##s >> 16) & 0xff] ^                   \
+             kStrideExtensionTable0[crc##s >> 24];                             \
+  } while (0)
 
 // Process a 16-byte swath of 4 strides, each of which has 4 bytes of data.
-#define STEP16 do {  \
-  STEP4(0);          \
-  STEP4(1);          \
-  STEP4(2);          \
-  STEP4(3);          \
-  p += 16;           \
-} while (0)
+#define STEP16 \
+  do {         \
+    STEP4(0);  \
+    STEP4(1);  \
+    STEP4(2);  \
+    STEP4(3);  \
+    p += 16;   \
+  } while (0)
 
 // Process 4 bytes that were already loaded into a word.
-#define STEP4W(w) do {                             \
-  w ^= l;                                          \
-  for (size_t i = 0; i < 4; ++i) {                 \
-    w = (w >> 8) ^ kByteExtensionTable[w & 0xff];  \
-  }                                                \
-  l = w;                                           \
-} while (0)
+#define STEP4W(w)                                   \
+  do {                                              \
+    w ^= l;                                         \
+    for (size_t i = 0; i < 4; ++i) {                \
+      w = (w >> 8) ^ kByteExtensionTable[w & 0xff]; \
+    }                                               \
+    l = w;                                          \
+  } while (0)
 
   // Point x at first 4-byte aligned byte in the buffer. This might be past the
   // end of the buffer.
@@ -301,11 +303,14 @@ uint32_t ExtendPortable(uint32_t crc, const uint8_t* data, size_t size) {
     uint32_t crc3 = ReadUint32LE(p + 3 * 4);
     p += 16;
 
-    while((e - p) > kPrefetchHorizon) {
+    while ((e - p) > kPrefetchHorizon) {
       RequestPrefetch(p + kPrefetchHorizon);
 
       // Process 64 bytes at a time.
-      STEP16; STEP16; STEP16; STEP16;
+      STEP16;
+      STEP16;
+      STEP16;
+      STEP16;
     }
 
     // Process one 16-byte swath at a time.

--- a/src/crc32c_portable_unittest.cc
+++ b/src/crc32c_portable_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_prefetch.h
+++ b/src/crc32c_prefetch.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
@@ -27,9 +27,8 @@ inline void RequestPrefetch(const uint8_t* address) {
 #if defined(HAVE_BUILTIN_PREFETCH)
   // Clang and GCC implement the __builtin_prefetch non-standard extension,
   // which maps to the best instruction on the target architecture.
-  __builtin_prefetch(
-      reinterpret_cast<const char*>(address),
-      0  /* Read only. */, 0  /* No temporal locality. */);
+  __builtin_prefetch(reinterpret_cast<const char*>(address), 0 /* Read only. */,
+                     0 /* No temporal locality. */);
 #elif defined(HAVE_MM_PREFETCH)
   // Visual Studio doesn't implement __builtin_prefetch, but exposes the
   // PREFETCHNTA instruction via the _mm_prefetch intrinsic.

--- a/src/crc32c_prefetch_unittest.cc
+++ b/src/crc32c_prefetch_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_read_le.h
+++ b/src/crc32c_read_le.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_read_le_unittest.cc
+++ b/src/crc32c_read_le_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_round_up.h
+++ b/src/crc32c_round_up.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_round_up_unittest.cc
+++ b/src/crc32c_round_up_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_sse42.cc
+++ b/src/crc32c_sse42.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_sse42.h
+++ b/src/crc32c_sse42.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_sse42_check.h
+++ b/src/crc32c_sse42_check.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_sse42_unittest.cc
+++ b/src/crc32c_sse42_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 

--- a/src/crc32c_unittest.cc
+++ b/src/crc32c_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The CRC32C Authors. All rights reserved.
+// Copyright 2017 The CRC32C Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 


### PR DESCRIPTION
Formatting was done via: `clang-format -style=Google`