### PR TITLE
Fix MSVC warnings in crc32c_unittest.cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,13 @@ target_include_directories(crc32c
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+# Warnings as errors in Visual Studio for this project's targets.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  set_property(TARGET crc32c APPEND PROPERTY COMPILE_OPTIONS "/WX")
+  set_property(TARGET crc32c_arm64 APPEND PROPERTY COMPILE_OPTIONS "/WX")
+  set_property(TARGET crc32c_sse42 APPEND PROPERTY COMPILE_OPTIONS "/WX")
+endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+
 if(CRC32C_BUILD_TESTS)
   enable_testing()
 
@@ -286,6 +293,12 @@ if(CRC32C_BUILD_TESTS)
       "${PROJECT_SOURCE_DIR}/src/crc32c_test_main.cc"
   )
   target_link_libraries(crc32c_tests crc32c gtest)
+
+  # Warnings as errors in Visual Studio for this project's targets.
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set_property(TARGET crc32c_tests APPEND PROPERTY COMPILE_OPTIONS "/WX")
+  endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+
   if(CRC32C_USE_GLOG)
     target_link_libraries(crc32c_tests glog)
   endif(CRC32C_USE_GLOG)
@@ -311,6 +324,11 @@ if(CRC32C_BUILD_BENCHMARKS)
   if(CRC32C_USE_GLOG)
     target_link_libraries(crc32c_bench glog)
   endif(CRC32C_USE_GLOG)
+
+  # Warnings as errors in Visual Studio for this project's targets.
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set_property(TARGET crc32c_bench APPEND PROPERTY COMPILE_OPTIONS "/WX")
+  endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif(CRC32C_BUILD_BENCHMARKS)
 
 if(CRC32C_INSTALL)

--- a/src/crc32c_sse42.cc
+++ b/src/crc32c_sse42.cc
@@ -236,7 +236,7 @@ uint32_t ExtendSse42(uint32_t crc, const uint8_t* data, size_t size) {
     STEP8(l64, p);
   }
 
-  l = l64;
+  l = static_cast<uint32_t>(l64);
   // Process the last few bytes.
   while (p != e) {
     STEP1;

--- a/src/crc32c_unittest.cc
+++ b/src/crc32c_unittest.cc
@@ -83,7 +83,7 @@ TEST(CRC32CTest, Crc32cStdString) {
   EXPECT_EQ(static_cast<uint32_t>(0x8a9136aa), crc32c::Crc32c(buf));
 
   for (size_t i = 0; i < 32; ++i)
-    buf[i] = static_cast<char>(0xff);
+    buf[i] = '\xff';
   EXPECT_EQ(static_cast<uint32_t>(0x62a8ab43), crc32c::Crc32c(buf));
 
   for (size_t i = 0; i < 32; ++i)


### PR DESCRIPTION
This also modifies the CMake configuration, so relevant build targets will be compiled with /WX (warnings-as-errors) on MSVC. This should help us catch similar errors in CI in the future.

This fixes the compile errors in https://luci-logdog.appspot.com/v/?s=chromium%2Fbb%2Fchromium.win%2FWin_x64_Builder__dbg_%2F57719%2F%2B%2Frecipes%2Fsteps%2Fcompile%2F0%2Fstdout