### PR TITLE
Disabled hardware acceleration on ARM.

### DIFF
--- a/src/crc32c_config.h.in
+++ b/src/crc32c_config.h.in
@@ -20,7 +20,9 @@
 
 // Define to 1 if targeting ARM and the compiler has the __crc32c{b,h,w,d} and
 // the vmull_p64 intrinsics.
-#cmakedefine HAVE_ARM64_CRC32C 1
+// Temporarily disabled to avoid crash on Qualcomm Snapdragon 410 MSM8916.
+// https://bugs.chromium.org/p/chromium/issues/detail?id=763848
+#cmakedefine HAVE_ARM64_CRC32C 0
 
 // Define to 1 if the system libraries have the getauxval function in the
 // <sys/auxv.h> header. Should be true on Linux and Android API level 20+.


### PR DESCRIPTION
crc32c::ExtendArm64 is crashing (SIGILL) at crc32c_arm64.cc:87. So far this
is on the following CPU's:

Asus Z00ED: Qualcomm Snapdragon 410 MSM8916, Quad Core 1.2GHz, Adreno 306
Asus Z010D: Qualcomm Snapdragon 615, MSM8939, 1.5 GHz Octa Core Processor
Asus Z00RD: Qualcomm Snapdragon 615.