### PR TITLE
Gate ARM64-accelerated impl on hwcap() having the HWCAP_PMULL flag.

### DIFF
--- a/src/crc32c_arm64_linux_check.h
+++ b/src/crc32c_arm64_linux_check.h
@@ -31,9 +31,11 @@ namespace crc32c {
 inline bool CanUseArm64Linux() {
 #if defined(HAVE_STRONG_GETAUXVAL) || defined(HAVE_WEAK_GETAUXVAL)
   // From 'arch/arm64/include/uapi/asm/hwcap.h' in Linux kernel source code.
-  constexpr unsigned long kHwCapCrc32 = 1 << 7;
+  constexpr unsigned long kHWCAP_PMULL = 1 << 4;
+  constexpr unsigned long kHWCAP_CRC32 = 1 << 7;
   unsigned long hwcap = (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
-  return (hwcap & kHwCapCrc32) != 0;
+  return (hwcap & (kHWCAP_PMULL | kHWCAP_CRC32)) ==
+         (kHWCAP_PMULL | kHWCAP_CRC32);
 #else
   return false;
 #endif  // defined(HAVE_STRONG_GETAUXVAL) || defined(HAVE_WEAK_GETAUXVAL)


### PR DESCRIPTION
The hardware-accelerated CRC32C implementation that takes advantage of ARM64 instructions is currently runtime-gated on hwcap() returning a value that has the HWCAP_CRC32 flag set. This covers the __crc32c{b,h,w,d} intrinsics, but does not cover the vmull_p64 call. The later should be gated on the presence of the HWCAP_PMULL flag.

This is a speculative fix for Chrome crashes observed at the first vmull_64 callsite on MSM8916-based boards.