### PR TITLE
Fix SSE4.2 arch flag for MSVC in CMake config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ target_sources(crc32c_sse42
 )
 if(HAVE_SSE42)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_compile_options(crc32c_sse42 PRIVATE "/arch:NOTYET")
+    target_compile_options(crc32c_sse42 PRIVATE "/arch:AVX")
   else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(crc32c_sse42 PRIVATE "-msse4.2")
   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
The old flag was a copy-paste error. We only use /arch:NOTYET for the ARM64-specific hardware accelerated implementation, because Visual Studio does not yet have an equivalent to -march=armv8-a+crc+crypto.