### PR TITLE
Migrate to 0/1 feature detection macros.

### DIFF
--- a/src/crc32c.cc
+++ b/src/crc32c.cc
@@ -16,13 +16,13 @@
 namespace crc32c {
 
 uint32_t Extend(uint32_t crc, const uint8_t* data, size_t count) {
-#if defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#if HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
   static bool can_use_sse42 = CanUseSse42();
   if (can_use_sse42) return ExtendSse42(crc, data, count);
-#elif defined(HAVE_ARM64_CRC32C)
+#elif HAVE_ARM64_CRC32C
   static bool can_use_arm_linux = CanUseArm64Linux();
   if (can_use_arm_linux) return ExtendArm64(crc, data, count);
-#endif
+#endif  // HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
   return ExtendPortable(crc, data, count);
 }

--- a/src/crc32c_arm64.cc
+++ b/src/crc32c_arm64.cc
@@ -16,7 +16,7 @@
 #include "./crc32c_internal.h"
 #include "crc32c/crc32c_config.h"
 
-#if defined(HAVE_ARM64_CRC32C)
+#if HAVE_ARM64_CRC32C
 
 #include <arm_acle.h>
 #include <arm_neon.h>
@@ -121,4 +121,4 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
 
 }  // namespace crc32c
 
-#endif  // defined(HAVE_ARM64_CRC32C)
+#endif  // HAVE_ARM64_CRC32C

--- a/src/crc32c_arm64.h
+++ b/src/crc32c_arm64.h
@@ -12,7 +12,7 @@
 
 #include "crc32c/crc32c_config.h"
 
-#if defined(HAVE_ARM64_CRC32C)
+#if HAVE_ARM64_CRC32C
 
 namespace crc32c {
 
@@ -20,6 +20,6 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t* data, size_t count);
 
 }  // namespace crc32c
 
-#endif  // defined(HAVE_ARM64_CRC32C)
+#endif  // HAVE_ARM64_CRC32C
 
 #endif  // CRC32C_CRC32C_ARM_LINUX_H_

--- a/src/crc32c_arm64_linux_check.h
+++ b/src/crc32c_arm64_linux_check.h
@@ -14,22 +14,22 @@
 
 #include "crc32c/crc32c_config.h"
 
-#if defined(HAVE_ARM64_CRC32C)
+#if HAVE_ARM64_CRC32C
 
-#if defined(HAVE_STRONG_GETAUXVAL)
+#if HAVE_STRONG_GETAUXVAL
 #include <sys/auxv.h>
-#elif defined(HAVE_WEAK_GETAUXVAL)
+#elif HAVE_WEAK_GETAUXVAL
 // getauxval() is not available on Android until API level 20. Link it as a weak
 // symbol.
 extern "C" unsigned long getauxval(unsigned long type) __attribute__((weak));
 
 #define AT_HWCAP 16
-#endif  // defined(HAVE_STRONG_GETAUXVAL) || defined(HAVE_WEAK_GETAUXVAL)
+#endif  // HAVE_STRONG_GETAUXVAL || HAVE_WEAK_GETAUXVAL
 
 namespace crc32c {
 
 inline bool CanUseArm64Linux() {
-#if defined(HAVE_STRONG_GETAUXVAL) || defined(HAVE_WEAK_GETAUXVAL)
+#if HAVE_STRONG_GETAUXVAL || HAVE_WEAK_GETAUXVAL
   // From 'arch/arm64/include/uapi/asm/hwcap.h' in Linux kernel source code.
   constexpr unsigned long kHWCAP_PMULL = 1 << 4;
   constexpr unsigned long kHWCAP_CRC32 = 1 << 7;
@@ -38,11 +38,11 @@ inline bool CanUseArm64Linux() {
          (kHWCAP_PMULL | kHWCAP_CRC32);
 #else
   return false;
-#endif  // defined(HAVE_STRONG_GETAUXVAL) || defined(HAVE_WEAK_GETAUXVAL)
+#endif  // HAVE_STRONG_GETAUXVAL || HAVE_WEAK_GETAUXVAL
 }
 
 }  // namespace crc32c
 
-#endif  // defined(HAVE_ARM64_CRC32C)
+#endif  // HAVE_ARM64_CRC32C
 
 #endif  // CRC32C_CRC32C_ARM_LINUX_CHECK_H_

--- a/src/crc32c_arm64_unittest.cc
+++ b/src/crc32c_arm64_unittest.cc
@@ -4,10 +4,10 @@
 
 #include "./crc32c_arm64.h"
 
-#if defined(HAVE_ARM64_CRC32C)
+#if HAVE_ARM64_CRC32C
 
 #define TESTED_EXTEND ExtendArm64
 #include "./crc32c_extend_unittests.h"
 #undef TESTED_EXTEND
 
-#endif  // defined(HAVE_ARM64_CRC32C)
+#endif  // HAVE_ARM64_CRC32C

--- a/src/crc32c_benchmark.cc
+++ b/src/crc32c_benchmark.cc
@@ -9,7 +9,7 @@
 
 #include "benchmark/benchmark.h"
 
-#ifdef CRC32C_TESTS_BUILT_WITH_GLOG
+#if CRC32C_TESTS_BUILT_WITH_GLOG
 #include "glog/logging.h"
 #endif  // CRC32C_TESTS_BUILT_WITH_GLOG
 
@@ -54,7 +54,8 @@ BENCHMARK_REGISTER_F(CRC32CBenchmark, Portable)
     ->RangeMultiplier(16)
     ->Range(256, 16777216);  // Block size.
 
-#if defined(HAVE_ARM64_CRC32C)
+#if HAVE_ARM64_CRC32C
+
 BENCHMARK_DEFINE_F(CRC32CBenchmark, ArmLinux)(benchmark::State& state) {
   if (!crc32c::CanUseArm64Linux()) {
     state.SkipWithError("ARM CRC32C instructions not available or not enabled");
@@ -69,9 +70,10 @@ BENCHMARK_DEFINE_F(CRC32CBenchmark, ArmLinux)(benchmark::State& state) {
 BENCHMARK_REGISTER_F(CRC32CBenchmark, ArmLinux)
     ->RangeMultiplier(16)
     ->Range(256, 16777216);  // Block size.
-#endif                       // defined(HAVE_ARM64_CRC32C)
 
-#if defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#endif  // HAVE_ARM64_CRC32C
+
+#if HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
 BENCHMARK_DEFINE_F(CRC32CBenchmark, Sse42)(benchmark::State& state) {
   if (!crc32c::CanUseSse42()) {
@@ -88,10 +90,10 @@ BENCHMARK_REGISTER_F(CRC32CBenchmark, Sse42)
     ->RangeMultiplier(16)
     ->Range(256, 16777216);  // Block size.
 
-#endif  // defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#endif  // HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
 int main(int argc, char** argv) {
-#ifdef CRC32C_TESTS_BUILT_WITH_GLOG
+#if CRC32C_TESTS_BUILT_WITH_GLOG
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
 #endif  // CRC32C_TESTS_BUILT_WITH_GLOG

--- a/src/crc32c_config.h.in
+++ b/src/crc32c_config.h.in
@@ -6,31 +6,31 @@
 #define CRC32C_CRC32C_CONFIG_H_
 
 // Define to 1 if building for a big-endian platform.
-#cmakedefine BYTE_ORDER_BIG_ENDIAN 1
+#cmakedefine01 BYTE_ORDER_BIG_ENDIAN
 
 // Define to 1 if the compiler has the __builtin_prefetch intrinsic.
-#cmakedefine HAVE_BUILTIN_PREFETCH 1
+#cmakedefine01 HAVE_BUILTIN_PREFETCH
 
 // Define to 1 if targeting X86 and the compiler has the _mm_prefetch intrinsic.
-#cmakedefine HAVE_MM_PREFETCH 1
+#cmakedefine01 HAVE_MM_PREFETCH
 
 // Define to 1 if targeting X86 and the compiler has the _mm_crc32_u{8,32,64}
 // intrinsics.
-#cmakedefine HAVE_SSE42 1
+#cmakedefine01 HAVE_SSE42
 
 // Define to 1 if targeting ARM and the compiler has the __crc32c{b,h,w,d} and
 // the vmull_p64 intrinsics.
-#cmakedefine HAVE_ARM64_CRC32C 1
+#cmakedefine01 HAVE_ARM64_CRC32C
 
 // Define to 1 if the system libraries have the getauxval function in the
 // <sys/auxv.h> header. Should be true on Linux and Android API level 20+.
-#cmakedefine HAVE_STRONG_GETAUXVAL 1
+#cmakedefine01 HAVE_STRONG_GETAUXVAL
 
 // Define to 1 if the compiler supports defining getauxval as a weak symbol.
 // Should be true for any compiler that supports __attribute__((weak)).
-#cmakedefine HAVE_WEAK_GETAUXVAL 1
+#cmakedefine01 HAVE_WEAK_GETAUXVAL
 
 // Define to 1 if CRC32C tests have been built with Google Logging.
-#cmakedefine CRC32C_TESTS_BUILT_WITH_GLOG 1
+#cmakedefine01 CRC32C_TESTS_BUILT_WITH_GLOG
 
 #endif  // CRC32C_CRC32C_CONFIG_H_

--- a/src/crc32c_prefetch.h
+++ b/src/crc32c_prefetch.h
@@ -10,7 +10,7 @@
 
 #include "crc32c/crc32c_config.h"
 
-#if defined(HAVE_MM_PREFETCH)
+#if HAVE_MM_PREFETCH
 
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -18,25 +18,25 @@
 #include <xmmintrin.h>
 #endif  // defined(_MSC_VER)
 
-#endif  // defined(HAVE_MM_PREFETCH)
+#endif  // HAVE_MM_PREFETCH
 
 namespace crc32c {
 
 // Ask the hardware to prefetch the data at the given address into the L1 cache.
 inline void RequestPrefetch(const uint8_t* address) {
-#if defined(HAVE_BUILTIN_PREFETCH)
+#if HAVE_BUILTIN_PREFETCH
   // Clang and GCC implement the __builtin_prefetch non-standard extension,
   // which maps to the best instruction on the target architecture.
   __builtin_prefetch(reinterpret_cast<const char*>(address), 0 /* Read only. */,
                      0 /* No temporal locality. */);
-#elif defined(HAVE_MM_PREFETCH)
+#elif HAVE_MM_PREFETCH
   // Visual Studio doesn't implement __builtin_prefetch, but exposes the
   // PREFETCHNTA instruction via the _mm_prefetch intrinsic.
   _mm_prefetch(reinterpret_cast<const char*>(address), _MM_HINT_NTA);
 #else
   // No prefetch support. Silence compiler warnings.
   (void)address;
-#endif  // defined(HAVE_BUILTIN_PREFETCH)
+#endif  // HAVE_BUILTIN_PREFETCH
 }
 
 }  // namespace crc32c

--- a/src/crc32c_sse42.cc
+++ b/src/crc32c_sse42.cc
@@ -19,7 +19,7 @@
 #include "./crc32c_round_up.h"
 #include "crc32c/crc32c_config.h"
 
-#if defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#if HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -253,4 +253,4 @@ uint32_t ExtendSse42(uint32_t crc, const uint8_t* data, size_t size) {
 
 }  // namespace crc32c
 
-#endif  // defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#endif  // HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))

--- a/src/crc32c_sse42.h
+++ b/src/crc32c_sse42.h
@@ -17,7 +17,7 @@
 // portable version. Most X86 machines are 64-bit nowadays, so it doesn't make
 // much sense to spend time building an optimized hardware-accelerated
 // implementation.
-#if defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#if HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
 namespace crc32c {
 
@@ -26,6 +26,6 @@ uint32_t ExtendSse42(uint32_t crc, const uint8_t* data, size_t count);
 
 }  // namespace crc32c
 
-#endif  // defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#endif  // HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
 #endif  // CRC32C_CRC32C_SSE42_H_

--- a/src/crc32c_sse42_check.h
+++ b/src/crc32c_sse42_check.h
@@ -12,7 +12,7 @@
 
 #include "crc32c/crc32c_config.h"
 
-#if defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#if HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
 // If the compiler supports SSE4.2, it definitely supports X86.
 
@@ -43,6 +43,6 @@ inline bool CanUseSse42() {
 
 #endif  // defined(_MSC_VER)
 
-#endif  // defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#endif  // HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
 #endif  // CRC32C_CRC32C_SSE42_CHECK_H_

--- a/src/crc32c_sse42_unittest.cc
+++ b/src/crc32c_sse42_unittest.cc
@@ -4,10 +4,10 @@
 
 #include "./crc32c_sse42.h"
 
-#if defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#if HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
 #define TESTED_EXTEND ExtendSse42
 #include "./crc32c_extend_unittests.h"
 #undef TESTED_EXTEND
 
-#endif  // defined(HAVE_SSE42) && (defined(_M_X64) || defined(__x86_64__))
+#endif  // HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))

--- a/src/crc32c_test_main.cc
+++ b/src/crc32c_test_main.cc
@@ -6,12 +6,12 @@
 
 #include "gtest/gtest.h"
 
-#ifdef CRC32C_TESTS_BUILT_WITH_GLOG
+#if CRC32C_TESTS_BUILT_WITH_GLOG
 #include "glog/logging.h"
 #endif  // CRC32C_TESTS_BUILT_WITH_GLOG
 
 int main(int argc, char** argv) {
-#ifdef CRC32C_TESTS_BUILT_WITH_GLOG
+#if CRC32C_TESTS_BUILT_WITH_GLOG
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
 #endif  // CRC32C_TESTS_BUILT_WITH_GLOG


### PR DESCRIPTION
The build system previously defined macros corresponding to detected features, and left the other macros undefined. After this change, all the feature detection macros are defined. Macros for detected features
are 1, and the other macros are 0.

This makes it slightly more difficult to embed crc32c in a system that doesn't use the CMake generator, but reduces the possibility of the library not using features due to accidental misconfiguration.