### PR TITLE
Remove unofficial product notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/google/crc32c.svg?branch=master)](https://travis-ci.org/google/crc32c)
 [![Build Status](https://ci.appveyor.com/api/projects/status/moiq7331pett4xuj/branch/master?svg=true)](https://ci.appveyor.com/project/pwnall/crc32c)
 
-**This is not an official Google product.**
 New file format authors should consider
 [HighwayHash](https://github.com/google/highwayhash). The initial version of
 this code was extracted from [LevelDB](https://github.com/google/leveldb), which


### PR DESCRIPTION
This library ships in Chrome 62 and onwards, so the statement is no longer accurate.