### PR TITLE
Move string_view inclusion out of crc32c namespace

### DIFF
--- a/include/crc32c/crc32c.h
+++ b/include/crc32c/crc32c.h
@@ -65,9 +65,13 @@ inline uint32_t Crc32c(const std::string& string) {
                 string.size());
 }
 
+}  // namespace crc32c
+
 #if __cplusplus > 201402L
 #if __has_include(<string_view>)
 #include <string_view>
+
+namespace crc32c {
 
 // Computes the CRC32C of the bytes in the string_view.
 inline uint32_t Crc32c(const std::string_view& string_view) {
@@ -75,10 +79,10 @@ inline uint32_t Crc32c(const std::string_view& string_view) {
                 string_view.size());
 }
 
+}  // namespace crc32c
+
 #endif  // __has_include(<string_view>)
 #endif  // __cplusplus > 201402L
-
-}  // namespace crc32c
 
 #endif  /* defined(__cplusplus) */
 


### PR DESCRIPTION
crc32c.h includes \<string_view\> into crc32c namespace if it's compiled
as C++17 sources. However, the outer namespace confuses the declarations
in the header.