### PR TITLE
Support shared libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,7 @@ if(HAVE_ARM64_CRC32C)
     target_compile_options(crc32c_arm64 PRIVATE "-march=armv8-a+crc+crypto")
   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif(HAVE_ARM64_CRC32C)
+# CMake only enables PIC by default in SHARED and MODULE targets.
 set_property(TARGET crc32c_arm64 PROPERTY POSITION_INDEPENDENT_CODE
   "${BUILD_SHARED_LIBS}")
 
@@ -247,6 +248,7 @@ if(HAVE_SSE42)
     target_compile_options(crc32c_sse42 PRIVATE "-msse4.2")
   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif(HAVE_SSE42)
+# CMake only enables PIC by default in SHARED and MODULE targets.
 set_property(TARGET crc32c_sse42 PROPERTY POSITION_INDEPENDENT_CODE
   "${BUILD_SHARED_LIBS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,8 @@ if(HAVE_ARM64_CRC32C)
     target_compile_options(crc32c_arm64 PRIVATE "-march=armv8-a+crc+crypto")
   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif(HAVE_ARM64_CRC32C)
+set_property(TARGET crc32c_arm64 PROPERTY POSITION_INDEPENDENT_CODE
+  "${BUILD_SHARED_LIBS}")
 
 # SSE4.2 code is built separately, so we don't accidentally compile unsupported
 # instructions into code that gets run without SSE4.2 support.
@@ -245,6 +247,8 @@ if(HAVE_SSE42)
     target_compile_options(crc32c_sse42 PRIVATE "-msse4.2")
   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif(HAVE_SSE42)
+set_property(TARGET crc32c_sse42 PROPERTY POSITION_INDEPENDENT_CODE
+  "${BUILD_SHARED_LIBS}")
 
 add_library(crc32c ""
   # TODO(pwnall): Move the TARGET_OBJECTS generator expressions to the PRIVATE


### PR DESCRIPTION
When compiling shared libraries the object libraries also need to compile with `-fPIC`.
