### PR TITLE
Only set the POSITION_INDEPENDENT_CODE property when building a shard library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,9 +228,11 @@ if(HAVE_ARM64_CRC32C)
     target_compile_options(crc32c_arm64 PRIVATE "-march=armv8-a+crc+crypto")
   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif(HAVE_ARM64_CRC32C)
+
 # CMake only enables PIC by default in SHARED and MODULE targets.
-set_property(TARGET crc32c_arm64
-    PROPERTY POSITION_INDEPENDENT_CODE "${BUILD_SHARED_LIBS}")
+if(BUILD_SHARED_LIBS)
+  set_property(TARGET crc32c_arm64 PROPERTY POSITION_INDEPENDENT_CODE "True")
+endif(BUILD_SHARED_LIBS)
 
 # SSE4.2 code is built separately, so we don't accidentally compile unsupported
 # instructions into code that gets run without SSE4.2 support.
@@ -248,9 +250,11 @@ if(HAVE_SSE42)
     target_compile_options(crc32c_sse42 PRIVATE "-msse4.2")
   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif(HAVE_SSE42)
+
 # CMake only enables PIC by default in SHARED and MODULE targets.
-set_property(TARGET crc32c_sse42
-    PROPERTY POSITION_INDEPENDENT_CODE "${BUILD_SHARED_LIBS}")
+if(BUILD_SHARED_LIBS)
+  set_property(TARGET crc32c_sse42 PROPERTY POSITION_INDEPENDENT_CODE "True")
+endif(BUILD_SHARED_LIBS)
 
 add_library(crc32c ""
   # TODO(pwnall): Move the TARGET_OBJECTS generator expressions to the PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ endif(HAVE_ARM64_CRC32C)
 
 # CMake only enables PIC by default in SHARED and MODULE targets.
 if(BUILD_SHARED_LIBS)
-  set_property(TARGET crc32c_arm64 PROPERTY POSITION_INDEPENDENT_CODE "True")
+  set_property(TARGET crc32c_arm64 PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 endif(BUILD_SHARED_LIBS)
 
 # SSE4.2 code is built separately, so we don't accidentally compile unsupported
@@ -253,7 +253,7 @@ endif(HAVE_SSE42)
 
 # CMake only enables PIC by default in SHARED and MODULE targets.
 if(BUILD_SHARED_LIBS)
-  set_property(TARGET crc32c_sse42 PROPERTY POSITION_INDEPENDENT_CODE "True")
+  set_property(TARGET crc32c_sse42 PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 endif(BUILD_SHARED_LIBS)
 
 add_library(crc32c ""


### PR DESCRIPTION
This thus allows static libraries to also be built with POSITION_INDEPENDENT_CODE, by running cmake like so:

        cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ..

Previously the value was always forced to False when building a static library.
