### PR TITLE
Add fuzzing harness and cmake definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,13 @@ install:
 # below don't work on macOS. Fortunately, the path change above makes the
 # default values (clang and clang++) resolve to the correct compiler on macOS.
 - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    if [ "$CXX" = "clang++" ]; then export CXX="clang++-8" CC="clang-8"; fi;
+    if [ "$CXX" = "clang++" ]; then
+      export CXX="clang++-8" CC="clang-8" \
+             FUZZING=1 \
+             LIB_FUZZING_ENGINE="-fsanitize=fuzzer";
+    else
+      export FUZZING=0;
+    fi
   fi
 - echo ${CC}
 - echo ${CXX}
@@ -63,8 +69,14 @@ install:
 
 before_script:
 - mkdir -p build && cd build
-- cmake .. -G Ninja -DCRC32C_USE_GLOG=$GLOG -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-           -DBUILD_SHARED_LIBS=$SHARED_LIB
+- if [ ${FUZZING} -eq 1 ]; then
+    cmake .. -G Ninja -DCRC32C_USE_GLOG=$GLOG -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+    -DBUILD_SHARED_LIBS=NO -DCRC32C_FUZZING_BUILD=ON
+    -DCMAKE_CXX_FLAGS="-fsanitize=address,fuzzer-no-link";
+  else
+    cmake .. -G Ninja -DCRC32C_USE_GLOG=$GLOG -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+           -DBUILD_SHARED_LIBS=$SHARED_LIB;
+  fi
 - cmake --build .
 - cd ..
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ option(CRC32C_BUILD_TESTS "Build CRC32C's unit tests" ON)
 option(CRC32C_BUILD_BENCHMARKS "Build CRC32C's benchmarks" ON)
 option(CRC32C_USE_GLOG "Build CRC32C's tests with Google Logging" ON)
 option(CRC32C_INSTALL "Install CRC32C's header and library" ON)
+option(CRC32C_FUZZING_BUILD "Build CRC32C's fuzzer" OFF)
 
 include(TestBigEndian)
 test_big_endian(BYTE_ORDER_BIG_ENDIAN)
@@ -414,3 +415,22 @@ if(CRC32C_INSTALL)
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/Crc32c"
   )
 endif(CRC32C_INSTALL)
+
+if(CRC32C_FUZZING_BUILD)
+  if (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    message(WARNING "Fuzzing builds are only supported with Clang")
+  endif (NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  if (NOT DEFINED ENV{LIB_FUZZING_ENGINE})
+    message(WARNING "Fuzzing builds require LIB_FUZZING_ENGINE environment \
+variable to be set")
+  endif (NOT DEFINED ENV{LIB_FUZZING_ENGINE})
+endif(CRC32C_FUZZING_BUILD)
+
+if(CRC32C_FUZZING_BUILD)
+  add_executable(crc32c_fuzzer "")
+  target_sources(crc32c_fuzzer
+          PRIVATE
+          "${PROJECT_SOURCE_DIR}/src/crc32c_fuzzer.cc"
+          )
+  target_link_libraries(crc32c_fuzzer crc32c $ENV{LIB_FUZZING_ENGINE})
+endif(CRC32C_FUZZING_BUILD)

--- a/src/crc32c_fuzzer.cc
+++ b/src/crc32c_fuzzer.cc
@@ -1,0 +1,23 @@
+// Copyright 2019 The CRC32C Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+#include "crc32c/crc32c.h"
+
+#include <string>
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+	if (size == 0)
+		return 0;
+
+	// Hash contents of raw byte buffer
+	uint32_t hash = crc32c::Crc32c(data, size);
+	// Extend
+	hash = crc32c::Extend(hash, data, size);
+
+	// Hash contents of std::string
+	std::string dataString(data, data + size - 1);
+	hash = crc32c::Crc32c(dataString);
+	return 0;
+}


### PR DESCRIPTION
Hello,

I noticed that crc32_c is a security critical dependency of Chromium, so I went ahead and created this PR that adds a fuzzing harness that could then be used for continuous fuzzing via oss-fuzz.

CC @inferno-chromium @Dor1s