### PR TITLE
Remove unnecessary reinterpret_cast

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Google Inc.
 
 Fangming Fang <Fangming.Fang@arm.com>
 Vadim Skipin <vadim.skipin@gmail.com>
+Rodrigo Tobar <rtobar@icrar.org>

--- a/src/crc32c_arm64.cc
+++ b/src/crc32c_arm64.cc
@@ -72,7 +72,7 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
   const poly64_t k0 = 0x8d96551c, k1 = 0xbd6f81f8, k2 = 0xdcb17aa4;
 
   crc = crc ^ kCRC32Xor;
-  const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
+  const uint8_t *p = buf;
 
   while (length >= KBYTES) {
     crc0 = crc;

--- a/src/crc32c_arm64.cc
+++ b/src/crc32c_arm64.cc
@@ -62,7 +62,7 @@
 
 namespace crc32c {
 
-uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
+uint32_t ExtendArm64(uint32_t crc, const uint8_t *data, size_t size) {
   int64_t length = size;
   uint32_t crc0, crc1, crc2, crc3;
   uint64_t t0, t1, t2;
@@ -72,7 +72,6 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
   const poly64_t k0 = 0x8d96551c, k1 = 0xbd6f81f8, k2 = 0xdcb17aa4;
 
   crc = crc ^ kCRC32Xor;
-  const uint8_t *p = buf;
 
   while (length >= KBYTES) {
     crc0 = crc;
@@ -81,14 +80,14 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
     crc3 = 0;
 
     // Process 1024 bytes in parallel.
-    CRC32C1024BYTES(p);
+    CRC32C1024BYTES(data);
 
     // Merge the 4 partial CRC32C values.
     t2 = (uint64_t)vmull_p64(crc2, k2);
     t1 = (uint64_t)vmull_p64(crc1, k1);
     t0 = (uint64_t)vmull_p64(crc0, k0);
-    crc = __crc32cd(crc3, *(uint64_t *)p);
-    p += sizeof(uint64_t);
+    crc = __crc32cd(crc3, *(uint64_t *)data);
+    data += sizeof(uint64_t);
     crc ^= __crc32cd(0, t2);
     crc ^= __crc32cd(0, t1);
     crc ^= __crc32cd(0, t0);
@@ -97,23 +96,23 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
   }
 
   while (length >= 8) {
-    crc = __crc32cd(crc, *(uint64_t *)p);
-    p += 8;
+    crc = __crc32cd(crc, *(uint64_t *)data);
+    data += 8;
     length -= 8;
   }
 
   if (length & 4) {
-    crc = __crc32cw(crc, *(uint32_t *)p);
-    p += 4;
+    crc = __crc32cw(crc, *(uint32_t *)data);
+    data += 4;
   }
 
   if (length & 2) {
-    crc = __crc32ch(crc, *(uint16_t *)p);
-    p += 2;
+    crc = __crc32ch(crc, *(uint16_t *)data);
+    data += 2;
   }
 
   if (length & 1) {
-    crc = __crc32cb(crc, *p);
+    crc = __crc32cb(crc, *data);
   }
 
   return crc ^ kCRC32Xor;


### PR DESCRIPTION
I found this unnecessary `reinterpret_cast` while reading the code. Once removed, variable `p` becomes unnecessary and the `buf` parameter can be used directly. And since I touched all the lines using `buf` I took the chance and renamed it to `data` to better align it with the rest of the crc32c functions in the package.