### PR TITLE
add postfix 'd' for crc32c debug lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ add_library(crc32c ""
   $<TARGET_OBJECTS:crc32c_arm64>
   $<TARGET_OBJECTS:crc32c_sse42>
 )
+set_target_properties(crc32c PROPERTIES DEBUG_POSTFIX "d")
 target_sources(crc32c
   PRIVATE
     "${PROJECT_BINARY_DIR}/include/crc32c/crc32c_config.h"


### PR DESCRIPTION
This PR will append 'd' postfix for debug library in Visual Studio.

When people are using crc32c as a dependent library in their own project, and in debug mode, this PR will help them.