### PR TITLE
Downgrading `getauxval()` error to warning (aarch64)

### DIFF
--- a/src/crc32c_arm64_check.h
+++ b/src/crc32c_arm64_check.h
@@ -38,7 +38,10 @@ inline bool CanUseArm64Crc32() {
   // From 'arch/arm64/include/uapi/asm/hwcap.h' in Linux kernel source code.
   constexpr unsigned long kHWCAP_PMULL = 1 << 4;
   constexpr unsigned long kHWCAP_CRC32 = 1 << 7;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Waddress"
   unsigned long hwcap = (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
+#pragma GCC diagnostic pop
   return (hwcap & (kHWCAP_PMULL | kHWCAP_CRC32)) ==
          (kHWCAP_PMULL | kHWCAP_CRC32);
 #elif defined(__APPLE__)


### PR DESCRIPTION
Fixes compilation on Ubuntu18/aarch64 (ARM64)

**COMPILE ERROR:**

```
[ 60%] Building CXX object CMakeFiles/crc32c.dir/src/crc32c.cc.o
In file included from work/crc32c_git/src/crc32c.cc:11:0:
work/crc32c_git/src/./crc32c_arm64_check.h: In function ‘bool crc32c::CanUseArm64Crc32()’:
work/crc32c_git/src/./crc32c_arm64_check.h:41:37: error: the address of ‘long unsigned int getauxval(long unsigned int)’ will never be NULL [-Werror=address]
   unsigned long hwcap = (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
                          ~~~~~~~~~~~^~~~~~~~~~
cc1plus: all warnings being treated as errors
CMakeFiles/crc32c.dir/build.make:86: recipe for target 'CMakeFiles/crc32c.dir/src/crc32c.cc.o' failed
make[2]: *** [CMakeFiles/crc32c.dir/src/crc32c.cc.o] Error 1
```

**OS SPECIFICS:**
```
# uname -a
Linux zorpi4.org 5.4.0-1022-raspi #25~18.04.1-Ubuntu SMP PREEMPT Thu Oct 15 14:38:18 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
```
```
# cat /etc/os-release
NAME="Ubuntu"
VERSION="18.04.5 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.5 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```

**GCC VERSION:**
```
# gcc --version
gcc (Ubuntu/Linaro 7.5.0-3ubuntu1~18.04) 7.5.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```