### PR TITLE
Fix compilation warnings on ARM64 with old GCC versions.

### DIFF
--- a/src/crc32c_arm64_check.h
+++ b/src/crc32c_arm64_check.h
@@ -38,7 +38,15 @@ inline bool CanUseArm64Crc32() {
   // From 'arch/arm64/include/uapi/asm/hwcap.h' in Linux kernel source code.
   constexpr unsigned long kHWCAP_PMULL = 1 << 4;
   constexpr unsigned long kHWCAP_CRC32 = 1 << 7;
-  unsigned long hwcap = (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
+  unsigned long hwcap =
+#if HAVE_STRONG_GETAUXVAL
+      // Some compilers warn on (&getauxval != nullptr) in the block below.
+      getauxval(AT_HWCAP);
+#elif HAVE_WEAK_GETAUXVAL
+      (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
+#else
+#error This is supposed to be nested inside a check for HAVE_*_GETAUXVAL.
+#endif  // HAVE_STRONG_GETAUXVAL
   return (hwcap & (kHWCAP_PMULL | kHWCAP_CRC32)) ==
          (kHWCAP_PMULL | kHWCAP_CRC32);
 #elif defined(__APPLE__)


### PR DESCRIPTION
Tested on Chrome OS M93 Linux (Debian 10.10) on kukui.