### PR TITLE
Fix Windows CI build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,12 @@ if(CRC32C_BUILD_TESTS)
   # Warnings as errors in Visual Studio for this project's targets.
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set_property(TARGET crc32c_capi_tests APPEND PROPERTY COMPILE_OPTIONS "/WX")
+
+    # The Windows SDK version currently on CI produces warnings when some
+    # headers are #included using C99 compatibity mode or above. This workaround
+    # can be removed once the Windows SDK on our CI is upgraded.
+    set_property(TARGET crc32c_capi_tests
+        APPEND PROPERTY COMPILE_OPTIONS "/wd5105")
   endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
   add_test(NAME crc32c_capi_tests COMMAND crc32c_capi_tests)


### PR DESCRIPTION
The Windows SDK versions present on our CI options (GitHub Actions hosted runners, AppVeyor) have headers that cause compilation warnings when included with MSVC operating in modern C modes (C11+).

This PR disables the compilation warning caused by the Windows SDK headers, so we can get Windows feedback from CI. The warnings can be re-enabled when the Windows SDK used by our CI is upgraded to a version that doesn't trigger warnings.