### PR TITLE
cmake: Restrict check for CRC32C intrinsic to aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,8 +149,12 @@ check_cxx_source_compiles("
 #include <arm_neon.h>
 
 int main() {
+#ifdef __aarch64__
   __crc32cb(0, 0); __crc32ch(0, 0); __crc32cw(0, 0); __crc32cd(0, 0);
   vmull_p64(0, 0);
+#else
+#error CRC32C library does not support hardware acceleration on ARM 32-bit
+#endif
   return 0;
 }
 " HAVE_ARM64_CRC32C)


### PR DESCRIPTION
The `HAVE_ARM64_CRC32C` test can erroneously pass when building on armv7:
```
$ uname -m
armv7l
$ g++ -v
Using built-in specs.
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/lib/gcc/arm-linux-gnueabihf/11/lto-wrapper
Target: arm-linux-gnueabihf
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 11.3.0-1ubuntu1~22.04.1' --with-bugurl=file:///usr/share/doc/gcc-11/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-11 --program-prefix=arm-linux-gnueabihf- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libitm --disable-libquadmath --disable-libquadmath-support --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-sjlj-exceptions --with-arch=armv7-a+fp --with-float=hard --with-mode=thumb --disable-werror --enable-checking=release --build=arm-linux-gnueabihf --host=arm-linux-gnueabihf --target=arm-linux-gnueabihf
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 11.3.0 (Ubuntu 11.3.0-1ubuntu1~22.04.1) 
$ cmake -B build
$ grep build/CMakeFiles/CMakeOutput.log -A 17 -e HAVE_ARM64_CRC32C
Performing C++ SOURCE FILE Test HAVE_ARM64_CRC32C succeeded with the following output:
Change Dir: /home/hebasto/git/crc32c/build/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/gmake -f Makefile cmTC_72d1d/fast && /usr/bin/gmake  -f CMakeFiles/cmTC_72d1d.dir/build.make CMakeFiles/cmTC_72d1d.dir/build
gmake[1]: Entering directory '/home/hebasto/git/crc32c/build/CMakeFiles/CMakeTmp'
Building CXX object CMakeFiles/cmTC_72d1d.dir/src.cxx.o
/usr/bin/c++ -DHAVE_ARM64_CRC32C  -Wall -Wextra -Werror -fno-exceptions -fno-rtti  -march=armv8-a+crc+crypto -o CMakeFiles/cmTC_72d1d.dir/src.cxx.o -c /home/hebasto/git/crc32c/build/CMakeFiles/CMakeTmp/src.cxx
Linking CXX executable cmTC_72d1d
/usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_72d1d.dir/link.txt --verbose=1
/usr/bin/c++  -Wall -Wextra -Werror -fno-exceptions -fno-rtti  -march=armv8-a+crc+crypto -rdynamic CMakeFiles/cmTC_72d1d.dir/src.cxx.o -o cmTC_72d1d 
gmake[1]: Leaving directory '/home/hebasto/git/crc32c/build/CMakeFiles/CMakeTmp'


Source file was:

#include <arm_acle.h>
#include <arm_neon.h>

int main() {
  __crc32cb(0, 0); __crc32ch(0, 0); __crc32cw(0, 0); __crc32cd(0, 0);
  vmull_p64(0, 0);
  return 0;
}

```

That results in a broken library and failed tests.

This PR addresses the issue by narrowing the check to aarch64 platforms.