### PR TITLE
fix: calling function crc32::Crc32c is ambiguous

### DIFF
--- a/include/crc32c/crc32c.h
+++ b/include/crc32c/crc32c.h
@@ -11,7 +11,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
 
 #else  /* !defined(__cplusplus) */
 
@@ -59,30 +58,35 @@ inline uint32_t Crc32c(const char* data, size_t count) {
   return Extend(0, reinterpret_cast<const uint8_t*>(data), count);
 }
 
-// Computes the CRC32C of the string's content.
-inline uint32_t Crc32c(const std::string& string) {
-  return Crc32c(reinterpret_cast<const uint8_t*>(string.data()),
-                string.size());
-}
-
 }  // namespace crc32c
 
-#if __cplusplus > 201402L
-#if __has_include(<string_view>)
-#include <string_view>
+#if __cplusplus > 201402L && __has_include(<string_view>)
 
+#include <string_view>
 namespace crc32c {
 
 // Computes the CRC32C of the bytes in the string_view.
-inline uint32_t Crc32c(const std::string_view& string_view) {
+inline uint32_t Crc32c(std::string_view string_view) {
   return Crc32c(reinterpret_cast<const uint8_t*>(string_view.data()),
                 string_view.size());
 }
 
 }  // namespace crc32c
 
-#endif  // __has_include(<string_view>)
-#endif  // __cplusplus > 201402L
+#else
+
+#include <string>
+
+namespace crc32c {
+
+// Computes the CRC32C of the string's content.
+inline uint32_t Crc32c(const std::string& string) {
+  return Crc32c(reinterpret_cast<const uint8_t*>(string.data()), string.size());
+}
+
+}  // namespace crc32c
+
+#endif  // __cplusplus > 201402L && __has_include(<string_view>)
 
 #endif  /* defined(__cplusplus) */
 

--- a/src/crc32c_unittest.cc
+++ b/src/crc32c_unittest.cc
@@ -119,6 +119,8 @@ TEST(CRC32CTest, Crc32cStdStringView) {
   for (size_t i = 0; i < 32; ++i)
     buf[i] = static_cast<uint8_t>(31 - i);
   EXPECT_EQ(static_cast<uint32_t>(0x113fdb5c), crc32c::Crc32c(view));
+
+  EXPECT_EQ(static_cast<uint32_t>(0x691daa2f), crc32c::Crc32c("Hello World"));
 }
 
 #endif  // __has_include(<string_view>)


### PR DESCRIPTION
When using C++17 to call the function `crc32::Crc32c`, and the parameter type is `const char*`, there is ambiguity.