### PR TITLE
build: Drop endianess workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,6 @@ option(CRC32C_BUILD_BENCHMARKS "Build CRC32C's benchmarks" ON)
 option(CRC32C_USE_GLOG "Build CRC32C's tests with Google Logging" ON)
 option(CRC32C_INSTALL "Install CRC32C's header and library" ON)
 
-include(TestBigEndian)
-test_big_endian(BYTE_ORDER_BIG_ENDIAN)
-
 include(CheckCXXCompilerFlag)
 # Used by glog.
 check_cxx_compiler_flag(-Wno-deprecated CRC32C_HAVE_NO_DEPRECATED)

--- a/src/crc32c_config.h.in
+++ b/src/crc32c_config.h.in
@@ -5,9 +5,6 @@
 #ifndef CRC32C_CRC32C_CONFIG_H_
 #define CRC32C_CRC32C_CONFIG_H_
 
-// Define to 1 if building for a big-endian platform.
-#cmakedefine01 BYTE_ORDER_BIG_ENDIAN
-
 // Define to 1 if the compiler has the __builtin_prefetch intrinsic.
 #cmakedefine01 HAVE_BUILTIN_PREFETCH
 

--- a/src/crc32c_read_le.h
+++ b/src/crc32c_read_le.h
@@ -8,28 +8,18 @@
 #include <cstdint>
 #include <cstring>
 
-#include "crc32c/crc32c_config.h"
-
 namespace crc32c {
 
 // Reads a little-endian 32-bit integer from a 32-bit-aligned buffer.
 inline uint32_t ReadUint32LE(const uint8_t* buffer) {
-#if BYTE_ORDER_BIG_ENDIAN
   return ((static_cast<uint32_t>(static_cast<uint8_t>(buffer[0]))) |
           (static_cast<uint32_t>(static_cast<uint8_t>(buffer[1])) << 8) |
           (static_cast<uint32_t>(static_cast<uint8_t>(buffer[2])) << 16) |
           (static_cast<uint32_t>(static_cast<uint8_t>(buffer[3])) << 24));
-#else   // !BYTE_ORDER_BIG_ENDIAN
-  uint32_t result;
-  // This should be optimized to a single instruction.
-  std::memcpy(&result, buffer, sizeof(result));
-  return result;
-#endif  // BYTE_ORDER_BIG_ENDIAN
 }
 
 // Reads a little-endian 64-bit integer from a 64-bit-aligned buffer.
 inline uint64_t ReadUint64LE(const uint8_t* buffer) {
-#if BYTE_ORDER_BIG_ENDIAN
   return ((static_cast<uint64_t>(static_cast<uint8_t>(buffer[0]))) |
           (static_cast<uint64_t>(static_cast<uint8_t>(buffer[1])) << 8) |
           (static_cast<uint64_t>(static_cast<uint8_t>(buffer[2])) << 16) |
@@ -38,12 +28,6 @@ inline uint64_t ReadUint64LE(const uint8_t* buffer) {
           (static_cast<uint64_t>(static_cast<uint8_t>(buffer[5])) << 40) |
           (static_cast<uint64_t>(static_cast<uint8_t>(buffer[6])) << 48) |
           (static_cast<uint64_t>(static_cast<uint8_t>(buffer[7])) << 56));
-#else   // !BYTE_ORDER_BIG_ENDIAN
-  uint64_t result;
-  // This should be optimized to a single instruction.
-  std::memcpy(&result, buffer, sizeof(result));
-  return result;
-#endif  // BYTE_ORDER_BIG_ENDIAN
 }
 
 }  // namespace crc32c


### PR DESCRIPTION
This mirrors a change in leveldb: https://github.com/google/leveldb/commit/201f52201f5dd9701e7a8ceaa0ec4d344e69e022, now that compilers can better optimise the generic code.