### PR TITLE
Permit compilation under the rc of cmake 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5..4.0)
 project(Crc32c VERSION 1.1.0 LANGUAGES C CXX)
 
 # C standard can be overridden when this is used as a sub-project.
@@ -265,7 +265,7 @@ endif(BUILD_SHARED_LIBS)
 # Must be included before CMAKE_INSTALL_INCLUDEDIR is used.
 include(GNUInstallDirs)
 
-add_library(crc32c ""
+add_library(crc32c STATIC
   # TODO(pwnall): Move the TARGET_OBJECTS generator expressions to the PRIVATE
   # section of target_sources when cmake_minimum_required becomes 3.9 or above.
   $<TARGET_OBJECTS:crc32c_arm64>


### PR DESCRIPTION
The `crc32c` code is used under an (eoponymous) R package I look after. I was just informed by the maintainer of the CRAN repo for R that it no longer builds under the release candidate 4 of cmake 4.0.0.

I was able to a) verify this and b) establish that the recommended course of action form switching from an (outdated for cmake 4) minimum version to the lowest support (3.5) in a min..max format also listing the one tested (here 4.0) works.

The simple one-line change below implements this. I cannot really tell if a minimum of cmake 3.5 (released in 2016) is viable for everyone or not.  If you don't think this flies, please just ignore the PR.  I will make this change in my [downstream R [package](https://github.com/eddelbuettel/crc32c) to remain buildable at CRAN.

Thanks of course thanks for crc32c!